### PR TITLE
Set FILESEXTRAPATHS:prepend properly in tensorflow-lite_2.%.bbappend

### DIFF
--- a/meta-ml/recipes-libraries/tensorflow-lite/tensorflow-lite_2.%.bbappend
+++ b/meta-ml/recipes-libraries/tensorflow-lite/tensorflow-lite_2.%.bbappend
@@ -1,4 +1,4 @@
-FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI:append = " file://tensorflow-lite.pc.in"
 


### PR DESCRIPTION
The file "file://tensorflow-lite.pc.in" is not located in the "files" folder but the "tensorflow-lite" (aka ${PN}) folder.