### PR TITLE
Fix some optee lib folders for multilib setup.

### DIFF
--- a/meta-bsp/recipes-security/optee/optee-client-imx.inc
+++ b/meta-bsp/recipes-security/optee/optee-client-imx.inc
@@ -9,4 +9,6 @@ SRC_URI:prepend = "${OPTEE_CLIENT_SRC};branch=${SRCBRANCH} "
 
 OPTEE_CLIENT_SRC ?= "git://github.com/nxp-imx/imx-optee-client.git;protocol=https"
 
+EXTRA_OEMAKE:append = " LIBDIR=${libdir} CFG_TEE_PLUGIN_LOAD_PATH=${libdir}/tee-supplicant/plugins/"
+
 inherit pkgconfig

--- a/meta-bsp/recipes-security/optee/optee-test-imx.inc
+++ b/meta-bsp/recipes-security/optee/optee-test-imx.inc
@@ -8,6 +8,8 @@ SRC_URI:append = "file://musl-workaround.patch"
 
 OPTEE_TEST_SRC ?= "git://github.com/nxp-imx/imx-optee-test.git;protocol=https"
 
+EXTRA_OEMAKE:append = " CFG_TEE_PLUGIN_LOAD_PATH=${libdir}/tee-supplicant/plugins/"
+
 EXTRA_OEMAKE:append:libc-musl = " OPTEE_OPENSSL_EXPORT=${STAGING_INCDIR}"
 DEPENDS:append:libc-musl = " openssl"
 CFLAGS:append:libc-musl = " -Wno-error=deprecated-declarations"


### PR DESCRIPTION
In case of a multilib setup:

* optee_client needs to install its libs into the arch-specific lib folder (e.g. /usr/lib64).
* optee_client's tee-supplicant needs to look for plugins underneath the arch-specific lib folder (e.g. in /usr/lib64/tee-supplicant/plugins), as those plugins are basically just shared libs.
* optee_test needs to install its test supplicant plugin in the (arch-specific) plugin folder uses where tee-supplicant is now looking for them.