### PR TITLE
Tensorflow build fix

### DIFF
--- a/meta-ml/recipes-libraries/tensorflow-lite/tensorflow-lite_2.9.1.bb
+++ b/meta-ml/recipes-libraries/tensorflow-lite/tensorflow-lite_2.9.1.bb
@@ -45,6 +45,12 @@ EXTRA_OECMAKE_BUILD = "benchmark_model label_image"
 
 CXXFLAGS += "-fPIC"
 
+PYBIND11_INCLUDE = "${PYTHON_INCLUDE_DIR}/pybind11"
+NUMPY_INCLUDE = "${PKG_CONFIG_SYSROOT_DIR}/${PYTHON_SITEPACKAGES_DIR}/numpy/core/include"
+
+OECMAKE_C_FLAGS += "-I${PYTHON_INCLUDE_DIR} -I${PYBIND11_IN} -I${NUMPY_INCLUDE}"
+OECMAKE_CXX_FLAGS += "-I${PYTHON_INCLUDE_DIR} -I${PYBIND11_INCLUDE} -I${NUMPY_INCLUDE}"
+
 do_configure[network] = "1"
 do_configure:prepend() {
     export HTTP_PROXY=${http_proxy}

--- a/meta-ml/recipes-libraries/tensorflow-lite/tensorflow-lite_2.9.1.bb
+++ b/meta-ml/recipes-libraries/tensorflow-lite/tensorflow-lite_2.9.1.bb
@@ -4,8 +4,11 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=4158a261ca7f2525513e31ba9c50ae98"
 
 
-DEPENDS = "python3-numpy-native python3-pip-native python3-pybind11-native python3-wheel-native unzip-native \
-    python3 tensorflow-protobuf jpeg zlib ${BPN}-host-tools-native"
+DEPENDS = " \
+    python3-numpy-native python3-pip-native python3-pybind11-native \
+    python3-wheel-native unzip-native python3 python3-numpy python3-pybind11 \
+    tensorflow-protobuf jpeg zlib ${BPN}-host-tools-native\
+"
 
 require tensorflow-lite-${PV}.inc
 SRC_URI = "${TENSORFLOW_LITE_SRC};branch=${SRCBRANCH_tf};name=tf"


### PR DESCRIPTION
tensorflow-lite on kirkstone-5.15.71-2.2.0 release seems to be broken, without additional, custom changes in bbappend the build hangs on following error

```
/tmp/work/armv8a-poky-linux/tensorflow-lite/2.9.1-r0/git/tensorflow/lite/python/interpreter_wrapper/interpreter_wrapper_pybind11.cc
| /work/build-wayland/tmp/work/armv8a-poky-linux/tensorflow-lite/2.9.1-r0/git/tensorflow/lite/python/interpreter_wrapper/interpreter_wrapper_pybind11.cc:16:10: fatal error: pybind11/functional.h: No such file or
directory
| 16 | #include "pybind11/functional.h"
(...)
| In file included from /work/build-wayland/tmp/work/armv8a-poky-linux/tensorflow-lite/2.9.1-r0/git/tensorflow/lite/python/interpreter_wrapper/interpreter_wrapper.cc:15:
| /work/build-wayland/tmp/work/armv8a-poky-linux/tensorflow-lite/2.9.1-r0/git/tensorflow/lite/python/interpreter_wrapper/interpreter_wrapper.h:28:10: fatal error: Python.h: No such file or directory
| 28 | #include <Python.h>
| | ^~~~~~~~~~
| compilation terminated.
| ninja: build stopped: subcommand failed.
| WARNING: exit code 1 from a shell command.
ERROR: Task (/work/sources/meta-imx/meta-ml/recipes-libraries/tensorflow-lite/tensorflow-lite_2.9.1.bb:do_compile) failed with exit code '1'
```

Provided changes helps with finding header files and compile the tensorflow-lite recipe.