### PR TITLE
weston-init: Do not fail if weston.sh is not present

### DIFF
--- a/meta-bsp/recipes-graphics/wayland/weston-init.bbappend
+++ b/meta-bsp/recipes-graphics/wayland/weston-init.bbappend
@@ -25,7 +25,7 @@ do_install:append() {
     fi
 
     # Remove weston.sh installed by meta-freescale, it is superceded by weston-socket.sh
-    rm ${D}${sysconfdir}/profile.d/weston.sh
+    rm -f ${D}${sysconfdir}/profile.d/weston.sh
 
     # Include commented gbm-format
     if ! [ "${@bb.utils.contains('PACKAGECONFIG', 'gbm-format', 'yes', 'no', d)}" = "yes" ]; then


### PR DESCRIPTION
Meta-layer meta-imx could be included in builds not using 'fsl' or 'fslc' DISTROOVERRIDES. 
In such cases, weston.sh file is not present in the image, and the build fails with:

  rm: cannot remove '.../image/etc/profile.d/weston.sh': No such file or directory

Thus, use the "-f" switch to not fail in case a file is not present.