### PR TITLE
wpa-supplicant: fix if imx-nxp-bsp not defined

### DIFF
--- a/meta-bsp/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
+++ b/meta-bsp/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
@@ -3,9 +3,9 @@ FILESEXTRAPATHS:prepend:imx-nxp-bsp := "${THISDIR}/${PN}:"
 DEPENDS += "readline"
 
 # Add defconfig for NXP Wi-Fi version
-SRC_URI += "file://defconfig"
+SRC_URI:prepend:imx-nxp-bsp  = "file://defconfig "
 
-do_configure:prepend () {
+do_configure:prepend:imx-nxp-bsp () {
         # Overwrite defconfig with NXP Wi-Fi version
         install -m 0755 ${WORKDIR}/defconfig wpa_supplicant/defconfig
 


### PR DESCRIPTION
Hello,
I needed to build for another architecture for SDK reason.
I came across an issue : FILESEXTRAPATHS:prepend is dependent on imx-nxp-bsp, but not do_configure and SRC_URI. New version of Yocto (> Kirckstone) will consider that not finding defconfig is an error.
Thanks,