### PR TITLE
openssh: Remove the bbappend

### DIFF
--- a/meta-sdk/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/meta-sdk/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,4 +1,0 @@
-PACKAGECONFIG:mx6-nxp-bsp ??= ""
-PACKAGECONFIG:mx7-nxp-bsp ??= ""
-PACKAGECONFIG:mx8-nxp-bsp ??= ""
-PACKAGECONFIG:mx9-nxp-bsp ??= ""


### PR DESCRIPTION
The bbappend is added to disable rng-tools originally as [1], but the rng-tools has been already removed in oe-core as [2]. So no need to keep this bbappend which used to disable rng-tools. And the means used to disable rng-tools [1] also make the sshd service not work after the logic [3] introduced.

So remove the useless bbappend.

[1] https://github.com/nxp-imx/meta-imx/commit/6c9ad14f54a69752d25c2b68d5b0db96cac99140
[2] https://git.openembedded.org/openembedded-core/commit/?id=868dfb46d96a27ec9041cb902fb769330277257d
[3] https://git.openembedded.org/openembedded-core/commit/?id=bc830ad3c6a11af1a350dca7f33f0682aeee0d21