### PR TITLE
meta-imx-bsp: layer.conf: remove chromium browser layer compat

### DIFF
--- a/meta-imx-bsp/conf/layer.conf
+++ b/meta-imx-bsp/conf/layer.conf
@@ -14,7 +14,6 @@ LAYERSERIES_COMPAT_fsl-bsp-release = "mickledore nanbield"
 MIRRORS += "http://sourceforge.net/.* http://www.nxp.com/lgfiles/updates/other"
 
 # FIXME: Drop these lines when the external layers are marked compatible
-LAYERSERIES_COMPAT_chromium-browser-layer:append = " langdale mickledore"
 LAYERSERIES_COMPAT_imx-demo:append = " mickledore"
 
 # Define new EULAs and add them to the list defined in meta-freescale.


### PR DESCRIPTION
remove chromium browser layer compat append as at least commit [dc31889c0899971def535dc1c040edf18bc16691](https://github.com/OSSystems/meta-browser/blob/dc31889c0899971def535dc1c040edf18bc16691/meta-chromium/conf/layer.conf) contains requirements