### PR TITLE
Update linux-firmware_%.bbappend to match changes in imx-firmware repo where the subdirectory IW612_SD_RFTest has been removed

### DIFF
--- a/meta-imx-bsp/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/meta-imx-bsp/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -103,8 +103,6 @@ do_install:append () {
     install -m 0644 ${WORKDIR}/imx-firmware/nxp/FwImage_IW612_SD/sduart_nw61x_v1.bin.se ${D}${nonarch_base_libdir}/firmware/nxp
     install -m 0644 ${WORKDIR}/imx-firmware/nxp/FwImage_IW612_SD/sd_w61x_v1.bin.se      ${D}${nonarch_base_libdir}/firmware/nxp
     install -m 0644 ${WORKDIR}/imx-firmware/nxp/FwImage_IW612_SD/uartspi_n61x_v1.bin.se ${D}${nonarch_base_libdir}/firmware/nxp
-    install -d ${D}${nonarch_base_libdir}/firmware/nxp/IW612_SD_RFTest
-    install -m 0644 ${WORKDIR}/imx-firmware/nxp/FwImage_IW612_SD/IW612_SD_RFTest/*      ${D}${nonarch_base_libdir}/firmware/nxp/IW612_SD_RFTest
 }
 
 # Use the latest version of sdma firmware in firmware-imx


### PR DESCRIPTION
Recipe fails on do_install because the IW612_SD_RFTest subdirectory is no longer in-tree, it was removed in this commit: https://github.com/nxp-imx/imx-firmware/commit/9ba6bfbcda14be2c5841ecfba525d98c66698925