### PR TITLE
fix gstreamer-plugins-bas webrtc for 1.24

### DIFF
--- a/meta-imx-bsp/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.24.0.imx.bb
+++ b/meta-imx-bsp/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.24.0.imx.bb
@@ -99,7 +99,7 @@ PACKAGECONFIG[vulkan]          = "-Dvulkan=enabled,-Dvulkan=disabled,vulkan-load
 PACKAGECONFIG[wayland]         = "-Dwayland=enabled,-Dwayland=disabled,wayland-native wayland wayland-protocols libdrm"
 PACKAGECONFIG[webp]            = "-Dwebp=enabled,-Dwebp=disabled,libwebp"
 PACKAGECONFIG[webrtc]          = "-Dwebrtc=enabled,-Dwebrtc=disabled,libnice"
-PACKAGECONFIG[webrtcdsp]       = "-Dwebrtcdsp=enabled,-Dwebrtcdsp=disabled,webrtc-audio-processing"
+PACKAGECONFIG[webrtcdsp]       = "-Dwebrtcdsp=enabled,-Dwebrtcdsp=disabled,webrtc-audio-processing-1"
 PACKAGECONFIG[zbar]            = "-Dzbar=enabled,-Dzbar=disabled,zbar"
 PACKAGECONFIG[x11]             = "-Dx11=enabled,-Dx11=disabled,libxcb libxkbcommon"
 PACKAGECONFIG[x265]            = "-Dx265=enabled,-Dx265=disabled,x265"


### PR DESCRIPTION
The newer gstreamer requires webrtc-audio-processing-1.x