### PR TITLE
nnshark: Update nnshark_2023.11.imx.bb to commit 4ed6690

### DIFF
--- a/meta-imx-ml/recipes-nnstreamer/nnshark/nnshark_2023.11.imx.bb
+++ b/meta-imx-ml/recipes-nnstreamer/nnshark/nnshark_2023.11.imx.bb
@@ -16,7 +16,7 @@ DEPENDS = "\
 NNSHARK_SRC ?= "gitsm://github.com/nxp-imx/nnshark.git;protocol=https"
 SRCBRANCH ?= "2023.11.imx"
 SRC_URI = "${NNSHARK_SRC};branch=${SRCBRANCH}"
-SRCREV = "a5096a6dd1e05c9f1aa4613d9ff3fa46ef205883"
+SRCREV = "4ed66906b889e66a6458a1d2692790f64bf1c556"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
[YOCIMX-8341] [LF-13566]
Pick up the fix for can not fetch gstreamer common submodule from anongit.freedesktop.org/gstreamer/common.


(cherry picked from commit f23d0ce80d40c4128116fa0b4dde5f5af9b0357d)