### PR TITLE
Resolve "missing file imx-boot" error after meta-freescale Sept 17, 2024 update to uuu_bootloader_tag.bbclass

### DIFF
--- a/meta-imx-bsp/recipes-bsp/u-boot/u-boot-imx_2024.04.bb
+++ b/meta-imx-bsp/recipes-bsp/u-boot/u-boot-imx_2024.04.bb
@@ -26,12 +26,18 @@ inherit uuu_bootloader_tag
 UUU_BOOTLOADER                        = ""
 UUU_BOOTLOADER:mx6-generic-bsp        = "${UBOOT_BINARY}"
 UUU_BOOTLOADER:mx7-generic-bsp        = "${UBOOT_BINARY}"
+UUU_BOOTLOADER:mx8-generic-bsp        = ""
+UUU_BOOTLOADER:mx9-generic-bsp        = ""
 UUU_BOOTLOADER_TAGGED                 = ""
 UUU_BOOTLOADER_TAGGED:mx6-generic-bsp = "u-boot-tagged.${UBOOT_SUFFIX}"
 UUU_BOOTLOADER_TAGGED:mx7-generic-bsp = "u-boot-tagged.${UBOOT_SUFFIX}"
+UUU_BOOTLOADER_TAGGED:mx8-generic-bsp = ""
+UUU_BOOTLOADER_TAGGED:mx9-generic-bsp = ""
 UUU_BOOTLOADER_UNTAGGED                 = ""
 UUU_BOOTLOADER_UNTAGGED:mx6-generic-bsp = "u-boot-untagged.${UBOOT_SUFFIX}"
 UUU_BOOTLOADER_UNTAGGED:mx7-generic-bsp = "u-boot-untagged.${UBOOT_SUFFIX}"
+UUU_BOOTLOADER_UNTAGGED:mx8-generic-bsp = ""
+UUU_BOOTLOADER_UNTAGGED:mx9-generic-bsp = ""
 
 do_deploy:append:mx8m-generic-bsp() {
     # Deploy u-boot-nodtb.bin and fsl-imx8m*-XX.dtb for mkimage to generate boot binary


### PR DESCRIPTION
fix an imx8 build error caused by meta-freescale commit dd9125d436c574ddde18bbc4129eeda43dd20c2a on Sept 17 2024. That changed uuu_bootloader_tag.bbclass by adding a line to default the variable "UUU_BOOTLOADER" to "${UBOOT_BINARY}".

This recipe was previously overriding UUU_BOOTLOADER for the machines mx6-generic-bsp and mx7-generic-bsp, but all others (including imx8) had "UUU_BOOTLOADER" set to an empty string - which disables the cp command in meta-freescale's uuu_bootloader_tag.bbclass.

However the meta-freescale commit mentioned above broke this by adding overrides for "UUU_BOOTLOADER:mx8-generic-bsp" and "UUU_BOOTLOADER:mx9-generic-bsp". Those ":mx*-generic-bsp" overrides take priority over any plain "UUU_BOOTLOADER=" statements, regardless of layer priority. Thus that enabled the cp command mentioned above and mx8 builds now started looking for a file "imx-boot" in this u-boot-imx recipe, but it doesn't exist because this recipe doesn't make that file on mx8 devices.

So my proposed fix is to add machine specific overrides in this u-boot-imx recipe that will take priority over meta-freescale. Note that this will not affect the imx-boot recipe that does make the "imx-boot" file and thus needs UUU_BOOTLOADER" to have a different value