### PR TITLE
imx95-evk: Add device trees to uboot

### DIFF
--- a/meta-imx-bsp/conf/machine/include/imx95-evk.inc
+++ b/meta-imx-bsp/conf/machine/include/imx95-evk.inc
@@ -7,6 +7,7 @@ MACHINE_FEATURES:append:use-nxp-bsp = " nxpwifi-all-pcie nxpwifi-all-sdio jailho
 KERNEL_DEVICETREE = " \
     freescale/${KERNEL_DEVICETREE_BASENAME}.dtb \
 "
+UBOOT_DTB_NAME = "${KERNEL_DEVICETREE_BASENAME}.dtb"
 
 IMX_DEFAULT_BOOTLOADER:use-nxp-bsp = "u-boot-imx"
 IMX_DEFAULT_BOOTLOADER:use-mainline-bsp = "u-boot-fslc"


### PR DESCRIPTION
Currently DSI-to-HDMI doesn't work.
DRM fails to get a device with the following error:
`[ 3.454795] [drm:drm_bridge_attach] *ERROR* failed to attach bridge /soc/syscon@4b010000/bridge@8/ports/port@0 to encoder None-39: -19 [ 3.490304] [drm:drm_bridge_attach] *ERROR* failed to attach bridge /soc/bridge@4b0d0000/channel@0 to encoder None-39: -19 [ 3.501519] imx95-dpu 4b400000.display-controller: [drm] *ERROR* failed to attach bridge to encoder for stream0: -19
`

Loading correct DSI-to-HDMI device tree is required for HDMI to output video picture, and for weston service to not fail.
This commit add all the device trees listed in the machine configs to uboot by default.

The workaround currently: one has to interrupt uboot and load the device tree manually.
This should load device trees automatically, so that DSI-to-HDMI works out of the box.