### PR TITLE
wpa-supplicant: Fix missing defconfig file

### DIFF
--- a/meta-imx-bsp/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
+++ b/meta-imx-bsp/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
@@ -1,11 +1,11 @@
 FILESEXTRAPATHS:prepend:imx-nxp-bsp := "${THISDIR}/${PN}:"
 
-DEPENDS += "readline"
+DEPENDS:append:imx-nxp-bsp = " readline"
 
 # Add defconfig for NXP Wi-Fi version
-SRC_URI += "file://defconfig"
+SRC_URI:append:imx-nxp-bsp = " file://defconfig"
 
-do_configure:prepend () {
+do_configure:prepend:imx-nxp-bsp() {
         # Overwrite defconfig with NXP Wi-Fi version
         install -m 0755 ${WORKDIR}/defconfig wpa_supplicant/defconfig
 


### PR DESCRIPTION
Even if the recipe is not used Bitbake will complain

Unable to get checksum for wpa-supplicant SRC_URI entry defconfig: file could not be found|