### PR TITLE
dpdk: fix CVE-2024-11614

### DIFF
--- a/meta-imx-sdk/recipes-extended/dpdk/dpdk/CVE-2024-11614.patch
+++ b/meta-imx-sdk/recipes-extended/dpdk/dpdk/CVE-2024-11614.patch
@@ -1,0 +1,33 @@
+Subject: [PATCH] net/virtio: fix Rx checksum calculation
+
+If hdr->csum_start is larger than packet length, the len argument passed
+to rte_raw_cksum_mbuf() overflows and causes a segmentation fault.
+
+Ignore checksum computation in this case.
+
+CVE-2024-11614
+
+Fixes: ca7036b4af3a ("vhost: fix offload flags in Rx path")
+Signed-off-by: Maxime Gouin <maxime.gouin@6wind.com>
+Signed-off-by: Olivier Matz <olivier.matz@6wind.com>
+(cherry picked from commit 2b85965865e543373163577c0bba6c4e1dc3a3ad)
+---
+ lib/vhost/virtio_net.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/lib/vhost/virtio_net.c b/lib/vhost/virtio_net.c
+index 9f314f83c7..9c9d05d4d9 100644
+--- a/lib/vhost/virtio_net.c
++++ b/lib/vhost/virtio_net.c
+@@ -2593,6 +2593,9 @@ vhost_dequeue_offload(struct virtio_net *dev, struct virtio_net_hdr *hdr,
+ 			 */
+ 			uint16_t csum = 0, off;
+ 
++			if (hdr->csum_start >= rte_pktmbuf_pkt_len(m))
++				return;
++
+ 			if (rte_raw_cksum_mbuf(m, hdr->csum_start,
+ 					rte_pktmbuf_pkt_len(m) - hdr->csum_start, &csum) < 0)
+ 				return;
+-- 
+2.34.1

--- a/meta-imx-sdk/recipes-extended/dpdk/dpdk_22.11.bb
+++ b/meta-imx-sdk/recipes-extended/dpdk/dpdk_22.11.bb
@@ -11,6 +11,8 @@ DEPENDS = "numactl python3-pyelftools-native libpcap"
 SRC_URI = "${DPDK_SRC};nobranch=1"
 DPDK_SRC ?= "git://github.com/nxp-qoriq/dpdk;protocol=https"
 
+SRC_URI:append = " file://CVE-2024-11614.patch"
+
 STABLE = "-stable"
 SRCREV = "9298b898fe38482fbb293d431cdeea4297c17e70"
 


### PR DESCRIPTION
An out-of-bounds read vulnerability was found in DPDK's Vhost library checksum offload feature. This issue enables an untrusted or compromised guest to crash the hypervisor's vSwitch by forging Virtio descriptors to cause out-of-bounds reads. This flaw allows an attacker with a malicious VM using a virtio driver to cause the vhost-user side to crash by sending a packet with a Tx checksum offload request and an invalid csum_start offset.

Reference:
https://security-tracker.debian.org/tracker/CVE-2024-11614

Upstream-patch:
https://git.dpdk.org/dpdk/commit/?id=4dc4e33ffa108e945fc8a1e2bbc7819791faa61e