### PR TITLE
meta-imx:dpdk: fix CVE-2024-11614

### DIFF
--- a/meta-sdk/recipes-extended/dpdk/dpdk.inc
+++ b/meta-sdk/recipes-extended/dpdk/dpdk.inc
@@ -10,6 +10,8 @@ DPDK_SRC ?= "git://github.com/nxp-qoriq/dpdk;protocol=https"
 SRC_URI = "${DPDK_SRC};nobranch=1 \
 "
 
+SRC_URI:append = " file://CVE-2024-11614.patch"
+
 STABLE = "-stable"
 SRCREV = "de541ae3fa6e18fa0293991b40e84ac3814a750c"
 

--- a/meta-sdk/recipes-extended/dpdk/dpdk/CVE-2024-11614.patch
+++ b/meta-sdk/recipes-extended/dpdk/dpdk/CVE-2024-11614.patch
@@ -1,0 +1,43 @@
+From 4dc4e33ffa108e945fc8a1e2bbc7819791faa61e Mon Sep 17 00:00:00 2001
+From: Olivier Matz <olivier.matz@6wind.com>
+Date: Thu, 28 Nov 2024 12:09:56 +0100
+Subject: [PATCH] net/virtio: fix Rx checksum calculation
+
+If hdr->csum_start is larger than packet length, the len argument passed
+to rte_raw_cksum_mbuf() overflows and causes a segmentation fault.
+
+Ignore checksum computation in this case.
+
+CVE-2024-11614
+
+Fixes: ca7036b4af3a ("vhost: fix offload flags in Rx path")
+
+Signed-off-by: Maxime Gouin <maxime.gouin@6wind.com>
+Signed-off-by: Olivier Matz <olivier.matz@6wind.com>
+Reviewed-by: Maxime Coquelin <maxime.coquelin@redhat.com>
+
+CVE: CVE-2024-11614
+
+Upstream-Status: Backport [https://git.dpdk.org/dpdk/commit/?id=4dc4e33ffa108e945fc8a1e2bbc7819791faa61e]
+
+Signed-off-by: Min Wang1 <min.wang1.cn@windriver.com>
+---
+ lib/vhost/virtio_net.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/lib/vhost/virtio_net.c b/lib/vhost/virtio_net.c
+index be28ea5151..5df9e36bfd 100644
+--- a/lib/vhost/virtio_net.c
++++ b/lib/vhost/virtio_net.c
+@@ -2593,6 +2593,9 @@ vhost_dequeue_offload(struct virtio_net *dev, struct virtio_net_hdr *hdr,
+                         */
+                        uint16_t csum = 0, off;
+
++                       if (hdr->csum_start >= rte_pktmbuf_pkt_len(m))
++                               return;
++
+                        if (rte_raw_cksum_mbuf(m, hdr->csum_start,
+                                        rte_pktmbuf_pkt_len(m) - hdr->csum_start, &csum) < 0)
+                                return;
+--
+2.34.1


### PR DESCRIPTION
An out-of-bounds read vulnerability was found in DPDK's Vhost library checksum offload feature. This issue enables an
untrusted or compromised guest to crash the hypervisor's vSwitch by forging Virtio descriptors to cause out-of-bounds reads. This
flaw allows an attacker with a malicious VM using a virtio driver to cause the vhost-user side to crash by sending a packet with a
Tx checksum offload request and an invalid csum_start offset.

Reference: https://security-tracker.debian.org/tracker/CVE-2024-11614

Upstream-patch: https://git.dpdk.org/dpdk/commit/?id=4dc4e33ffa108e945fc8a1e2bbc7819791faa61e