### PR TITLE
imx-boot: backport: Fix 8M non multi-config build problem

### DIFF
--- a/meta-imx-bsp/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
+++ b/meta-imx-bsp/recipes-bsp/imx-mkimage/imx-boot_1.0.bb
@@ -106,7 +106,9 @@ compile_mx8m() {
         cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/${UBOOT_DTB_NAME_EXTRA} \
                                                              ${BOOT_STAGING}
     fi
-    ln -sf ${UBOOT_DTB_NAME_EXTRA}                           ${BOOT_STAGING}/${UBOOT_DTB_NAME}
+    if [ "${UBOOT_DTB_NAME_EXTRA}" != "${UBOOT_DTB_NAME}" ] ; then
+        ln -sf ${UBOOT_DTB_NAME_EXTRA}                       ${BOOT_STAGING}/${UBOOT_DTB_NAME}
+    fi
 
     cp ${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}/u-boot-nodtb.bin-${MACHINE}-${UBOOT_CONFIG_EXTRA} \
                                                              ${BOOT_STAGING}/u-boot-nodtb.bin


### PR DESCRIPTION
From c6f4b3c6e6e54d8fe0c892ece75dca2102ab04c2 Mon Sep 17 00:00:00 2001
From: Esben Haabendal <esben@geanix.com>
Date: Tue, 29 Oct 2024 21:27:13 +0100
Subject: [PATCH] imx-boot: Fix 8M non multi-config build problem

The fix made in commit 2db7047ba40e
("imx-boot: Fix 8M multi-config build problems")
broke builds not using U-Boot multi-config, as the link created ends up being a simple recursive link when UBOOT_DTB_NAME_EXTRA is the same as UBOOT_DTB_NAME. The fix made in commit 2db7047ba40e

It fails with something like this:
```
| ./../scripts/dtb_check.sh imx8mq-evk.dtb evk.dtb imx8mq-var-dart-dt8mcustomboard.dtb
|  Can't find u-boot DTB file, please copy from u-boot
```

caused by a symlink like this:
```
lrwxrwxrwx 1 esben 1000001 35 Oct 29 21:32 imx8mq-var-dart-dt8mcustomboard.dtb -> imx8mq-var-dart-dt8mcustomboard.dtb
```

Fixes: 2db7047ba40e ("imx-boot: Fix 8M multi-config build problems")
Signed-off-by: Esben Haabendal <esben@geanix.com>
(cherry picked from commit 7da235fbdd3dc521f5bfd368770b9a30b959e689)