### PR TITLE
tensorflow-lite-host-tools: fix do_configure failure when buildtools is

### DIFF
--- a/meta-imx-ml/recipes-libraries/tensorflow-lite/tensorflow-lite-host-tools_2.16.2.bb
+++ b/meta-imx-ml/recipes-libraries/tensorflow-lite/tensorflow-lite-host-tools_2.16.2.bb
@@ -26,4 +26,5 @@ do_configure:prepend() {
     export HTTPS_PROXY=${https_proxy}
     export http_proxy=${http_proxy}
     export https_proxy=${https_proxy}
+    export GIT_SSL_CAINFO=${GIT_SSL_CAINFO}
 }


### PR DESCRIPTION
used

When buildtools is used and nativesdk-git is installed into sdk, do_configure failed with error:
[1/9] Performing download step (git clone) for 'protobuf-populate' Cloning into 'protobuf'...
fatal: unable to access 'https://github.com/protocolbuffers/protobuf/': error setting certificate file: /usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-wrlinuxsdk-linux/etc/ssl/certs/ca-certificates.crt

With commit [1], GIT_SSL_CAINFO is added into BB_ENV_PASSTHROUGH_ADDITIONS, export GIT_SSL_CAINFO to fix above failure

[1] https://git.openembedded.org/openembedded-core/commit/?id=183e043de423fd3f7833366ca524a6f7d17e6d14