### PR TITLE
weston-init: Switch away from WORKDIR

### DIFF
--- a/meta-imx-bsp/recipes-graphics/wayland/weston-init.bbappend
+++ b/meta-imx-bsp/recipes-graphics/wayland/weston-init.bbappend
@@ -16,7 +16,7 @@ do_install:append() {
         update_file "Group=weston" "Group=root" ${D}${systemd_system_unitdir}/weston.service
     else
         # Install weston-socket.sh for sysvinit as well
-        install -D -p -m0644 ${WORKDIR}/weston-socket.sh ${D}${sysconfdir}/profile.d/weston-socket.sh
+        install -D -p -m0644 ${S}/weston-socket.sh ${D}${sysconfdir}/profile.d/weston-socket.sh
     fi
 
     # Include commented gbm-format


### PR DESCRIPTION
The source files are not unpacked to `WORKDIR` anymore. As recommended by the Yocto [Migration notes for 5.1 (styhead)](https://docs.yoctoproject.org/next/migration-guides/migration-5.1.html#migration-notes-for-5-1-styhead) the base recipe sets:
```
S = "${WORKDIR}/sources"
UNPACKDIR = "${S}"
```    
So, use `S` instead of `WORKDIR` to fix:
```
install: cannot stat '.../build/tmp/work/sailfish-poky-linux/weston-init/1.0/weston-socket.sh': No such file or directory
```