### PR TITLE
Remove installation of powerpc_rom.bin from qemu-system-native recipe

### DIFF
--- a/meta-imx-bsp/recipes-devtools/qemu/qemu-system-native_9.0.2.imx.bb
+++ b/meta-imx-bsp/recipes-devtools/qemu/qemu-system-native_9.0.2.imx.bb
@@ -17,8 +17,6 @@ PACKAGECONFIG ??= "fdt alsa kvm pie slirp png \
 PACKAGECONFIG:remove = "${@'kvm' if not os.path.exists('/usr/include/linux/kvm.h') else ''}"
 
 do_install:append() {
-    install -Dm 0755 ${UNPACKDIR}/powerpc_rom.bin ${D}${datadir}/qemu
-
     # The following is also installed by qemu-native
     rm -f ${D}${datadir}/qemu/trace-events-all
     rm -rf ${D}${datadir}/qemu/keymaps


### PR DESCRIPTION
This powerpc_rom.bin is not provided in the recipe files, so it can't be installed.