### PR TITLE
Ignore rm of old weston.sh if it is already gone

### DIFF
--- a/meta-bsp/recipes-graphics/wayland/weston-init.bbappend
+++ b/meta-bsp/recipes-graphics/wayland/weston-init.bbappend
@@ -25,7 +25,7 @@ do_install:append() {
     fi
 
     # Remove weston.sh installed by meta-freescale, it is superceded by weston-socket.sh
-    rm ${D}${sysconfdir}/profile.d/weston.sh
+    rm -f ${D}${sysconfdir}/profile.d/weston.sh
 
     # Include commented gbm-format
     if ! [ "${@bb.utils.contains('PACKAGECONFIG', 'gbm-format', 'yes', 'no', d)}" = "yes" ]; then


### PR DESCRIPTION
My yocto build failed because weston.sh was already gone, shouldn't happen.