### PR TITLE
Add CONFIG_CTRL_IFACE_DBUS_NEW to defconfig of wpa-supplicant

### DIFF
--- a/meta-imx-sdk/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
+++ b/meta-imx-sdk/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
@@ -16,5 +16,6 @@ S = "${WORKDIR}/wpa_supplicant-${PV}-${IMX_SRCREV_ABBREV}"
 
 do_configure:append:imx-nxp-bsp () {
     # Use NXP version of defconfig
-    cp wpa_supplicant/defconfig wpa_supplicant/.config
+    echo "CONFIG_CTRL_IFACE_DBUS_NEW=y" >> wpa_supplicant/defconfig
+    cp wpa_supplicant/defconfig wpa_supplicant/.config    
 }


### PR DESCRIPTION
This is needed so that network manager can communcate with wpa-supplicant over the dbus. NXP is using custom wpa-supplicant and custom config for it, so either we need this patch to be able to use it with networkmanager or it needs to be fixed in original defconfig of wpa-supplicant....