### PR TITLE
Topic/add openthread dynamic layers

### DIFF
--- a/meta-imx-sdk/conf/layer.conf
+++ b/meta-imx-sdk/conf/layer.conf
@@ -33,6 +33,9 @@ BBFILES_DYNAMIC += " \
     nxp-matter-baseline:${LAYERDIR}/dynamic-layers/matter-layer/*/*/*.bb \
     nxp-matter-baseline:${LAYERDIR}/dynamic-layers/matter-layer/*/*/*.bbappend \
     nxp-openthread:${LAYERDIR}/dynamic-layers/matter-layer/*/*/*.bbappend \
+    \
+    nxp-openthread:${LAYERDIR}/dynamic-layers/nxp-openthread/*/*/*.bb \
+    nxp-openthread:${LAYERDIR}/dynamic-layers/nxp-openthread/*/*/*.bbappend \
 "
 
 BBMASK += " \

--- a/meta-imx-sdk/dynamic-layers/matter-layer/recipes-fsl/packagegroup/packagegroup-fsl-tools-testapps.bbappend
+++ b/meta-imx-sdk/dynamic-layers/matter-layer/recipes-fsl/packagegroup/packagegroup-fsl-tools-testapps.bbappend
@@ -4,7 +4,6 @@
 NXP_MATTER_TOOLS ?= ""
 NXP_MATTER_TOOLS:imx-nxp-bsp = " \
     packagegroup-nxp-matter-baseline \
-    packagegroup-nxp-openthread \
 "
 
 RDEPENDS:${PN} += " \

--- a/meta-imx-sdk/dynamic-layers/nxp-openthread/recipes-fsl/packagegroup/packagegroup-fsl-tools-testapps.bbappend
+++ b/meta-imx-sdk/dynamic-layers/nxp-openthread/recipes-fsl/packagegroup/packagegroup-fsl-tools-testapps.bbappend
@@ -1,0 +1,11 @@
+# Add needed Freescale packages and definitions
+
+# Install openthread related tools
+NXP_OPENTHREAD_TOOLS ?= ""
+NXP_OPENTHREAD_TOOLS:imx-nxp-bsp = " \
+    packagegroup-nxp-openthread \
+"
+
+RDEPENDS:${PN} += " \
+    ${NXP_OPENTHREAD_TOOLS} \
+"


### PR DESCRIPTION
When meta-nxp-openthread isn’t added to bblayers.conf, the Matter dynamic-layer .bbappend tries to install a non-existent packagegroup in fsl-gui-image, causing a parse error. This commit fixes it by introducing a dedicated dynamic-layer for meta-nxp-openthread and moving that packagegroup handling there.