### PR TITLE
Ethos-u-vela: extend class for native and nativesdk space.

### DIFF
--- a/meta-imx-ml/recipes-libraries/ethos-u-vela/ethos-u-vela_4.3.0.bb
+++ b/meta-imx-ml/recipes-libraries/ethos-u-vela/ethos-u-vela_4.3.0.bb
@@ -15,6 +15,8 @@ S = "${WORKDIR}/git"
 
 inherit setuptools3
 
+BBCLASSEXTEND = "native nativesdk"
+
 do_compile[network] = "1"
 do_compile:prepend() {
     export HTTP_PROXY=${http_proxy}
@@ -26,5 +28,7 @@ do_compile:prepend() {
 RDEPENDS:${PN} += "python3-flatbuffers python3-numpy python3-lxml"
 
 COMPATIBLE_MACHINE = "(mx93-nxp-bsp)"
+COMPATIBLE_MACHINE:class-native = ".*"
+COMPATIBLE_MACHINE:class-nativesdk = ".*"
 
 INSANE_SKIP:${PN} = "already-stripped"


### PR DESCRIPTION
This allows yocto to optimize liteRT models at building time and install already optimized models.

For example, after applying this changes you can do the following install task in other recipe:

```shell
DEPENDS:append = " ethos-u-vela-native"

do_install:append() {
    vela "${UNPACKDIR}"/mobilenet_v1_1.0_224_quant.tflite
    install -m 0755 "${UNPACKDIR}"/output/mobilenet_v1_1.0_224_quant_vela.tflite "${D}"/../..
}
```
