### PR TITLE
sysvinit-inittab: Remove dependency on bash

### DIFF
--- a/meta-imx-bsp/recipes-core/sysvinit/sysvinit-inittab/imxgpu2d/rc_gpu.S
+++ b/meta-imx-bsp/recipes-core/sysvinit/sysvinit-inittab/imxgpu2d/rc_gpu.S
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 CPUREV=$(cat /sys/devices/soc0/soc_id)
 FILEVG=/usr/lib/libOpenVG.so
 FILEVGLIB=/usr/lib/libOpenVG.so.1
@@ -16,7 +16,7 @@ then
         rm -f $FILEVGLIB
   fi
 
-  if [ $CPUREV == "i.MX6QP" ] || [ $CPUREV == "i.MX6Q" ] || [ $CPUREV == "i.MX6SL" ]
+  if [ "$CPUREV" = "i.MX6QP" ] || [ "$CPUREV" = "i.MX6Q" ] || [ "$CPUREV" = "i.MX6SL" ]
   then
         # Use GC355 VG
         ln -s $FILEVG355 $FILEVG

--- a/meta-imx-bsp/recipes-core/sysvinit/sysvinit-inittab/imxgpu2d/rc_mxc.S
+++ b/meta-imx-bsp/recipes-core/sysvinit/sysvinit-inittab/imxgpu2d/rc_mxc.S
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 if grep -sq ttymxc0 /proc/cmdline; then
 	/sbin/getty -L ttymxc0 115200 vt100

--- a/meta-imx-bsp/recipes-core/sysvinit/sysvinit-inittab_2.88dsf.bbappend
+++ b/meta-imx-bsp/recipes-core/sysvinit/sysvinit-inittab_2.88dsf.bbappend
@@ -1,8 +1,6 @@
 # Freescale imx extra configuration 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-RDEPENDS:${PN} += " bash "
-
 SYSVINIT-GPU = " file://rc_mxc.S file://rc_gpu.S"
 
 SRC_URI:append:imxgpu2d  = " ${SYSVINIT-GPU}"


### PR DESCRIPTION
Depending on bash, even when these scripts are not needed at all, is not needed.